### PR TITLE
Release 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2025-08-23
+
+### Added
+- Added `snippets diff` command to compare local and database versions of a snippet, showing differences in both spec and content files in a git-like format
+- Added support for using PAGES_FOLDER path in pages push, pull, publish, unpublish and remove commands (e.g., workspace/pages/en/home)
+- Added repository difference indicators to `pages list` command: shows `*` for pages that have local changes, are missing local files, or exist locally but not in the database
+
 ## [2.0.4] - 2025-08-22
 
 ### Added

--- a/elementalcms/__init__.py
+++ b/elementalcms/__init__.py
@@ -15,7 +15,7 @@ from elementalcms.services.snippets import GetMe
 
 from elementalcms.presenter import presenter
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 
 
 class Elemental:

--- a/elementalcms/management/pages.py
+++ b/elementalcms/management/pages.py
@@ -55,7 +55,7 @@ class Pages(click.Group):
             '-p',
             nargs=2,
             multiple=True,
-            help='Name and language for the page(s) to be pushed. For example: push -p home en -p home es')
+            help='Name and language for the page(s) to be pushed. Can include PAGES_FOLDER path (e.g., workspace/pages/en/home). For example: push -p home en -p home es')
     @constraint(RequireExactly(1), ['all', 'page'])
     @pass_context
     def push(ctx, **params) -> [Tuple]:
@@ -73,7 +73,7 @@ class Pages(click.Group):
             '-p',
             nargs=2,
             multiple=True,
-            help='Name and language for the page(s) to be published. For example: publish -p home en -p home es')
+            help='Name and language for the page(s) to be published. Can include PAGES_FOLDER path (e.g., workspace/pages/en/home). For example: publish -p home en -p home es')
     @constraint(RequireExactly(1), ['all', 'page'])
     @pass_context
     def publish(ctx, **params) -> [Tuple]:
@@ -89,7 +89,7 @@ class Pages(click.Group):
             nargs=2,
             required=True,
             multiple=True,
-            help='Name and language for the page(s) to be unpublished. For example: unpublish -p home en -p home es')
+            help='Name and language for the page(s) to be unpublished. Can include PAGES_FOLDER path (e.g., workspace/pages/en/home). For example: unpublish -p home en -p home es')
     @pass_context
     def unpublish(ctx, page) -> [Tuple]:
         return Unpublish(ctx).exec(page)
@@ -104,7 +104,7 @@ class Pages(click.Group):
             '-p',
             nargs=2,
             multiple=True,
-            help='Name and language for the page to be pulled. For example: pull -p home en -p home es')
+            help='Name and language for the page to be pulled. Can include PAGES_FOLDER path (e.g., workspace/pages/en/home). For example: pull -p home en -p home es')
     @constraint(RequireExactly(1), ['all', 'page'])
     @option('--drafts',
             is_flag=True,
@@ -122,7 +122,7 @@ class Pages(click.Group):
             '-p',
             nargs=2,
             required=True,
-            help='Name and language for the page to be pulled. For example: remove -p home es')
+            help='Name and language for the page to be removed. Can include PAGES_FOLDER path (e.g., workspace/pages/en/home). For example: remove -p home es')
     @pass_context
     def remove(ctx, page) -> Optional[Tuple]:
         return Remove(ctx).exec(page)

--- a/elementalcms/management/pagescommands/list.py
+++ b/elementalcms/management/pagescommands/list.py
@@ -1,4 +1,7 @@
+import json
+import os
 import click
+from bson import json_util
 
 from elementalcms.core import ElementalContext
 from elementalcms.services.pages import GetAll
@@ -9,13 +12,73 @@ class List:
     def __init__(self, ctx):
         self.context: ElementalContext = ctx.obj['elemental_context']
 
+    def has_local_changes(self, db_page) -> bool:
+        folder_path = f'{self.context.cms_core_context.PAGES_FOLDER}/{db_page["language"]}'
+        name = db_page['name']
+        
+        # Check if local files exist
+        spec_path = f'{folder_path}/{name.replace("/", "_")}.json'
+        content_path = f'{folder_path}/{name.replace("/", "_")}.html'
+        if not os.path.exists(spec_path) or not os.path.exists(content_path):
+            return True  # Missing local files is a difference!
+            
+        # Compare spec (excluding content and timestamps)
+        with open(spec_path, encoding='utf-8') as f:
+            local_spec = json_util.loads(f.read())
+            db_spec = json_util.loads(json_util.dumps(db_page))  # Clone to avoid modifying original
+            
+            # Remove fields we don't want to compare
+            for spec in [local_spec, db_spec]:
+                spec.pop('content', None)
+                spec.pop('createdAt', None)
+                spec.pop('lastModifiedAt', None)
+            
+            if local_spec != db_spec:
+                return True
+                
+        # Compare content
+        with open(content_path, encoding='utf-8') as f:
+            local_content = f.read()
+            if local_content != db_page.get('content', ''):
+                return True
+                
+        return False
+
+    def get_local_pages(self):
+        root_folder_path = self.context.cms_core_context.PAGES_FOLDER
+        if not os.path.exists(root_folder_path):
+            os.makedirs(root_folder_path)
+        
+        local_pages = set()
+        for lang in self.context.cms_core_context.LANGUAGES:
+            folder_path = f'{root_folder_path}/{lang}'
+            if not os.path.exists(folder_path):
+                continue
+            for file in os.listdir(folder_path):
+                if file.endswith('.json'):
+                    name = file[:-5].replace('_', '/')  # Remove .json and restore slashes
+                    local_pages.add((name, lang))
+        return local_pages
+
     def exec(self, drafts=False):
         result = GetAll(self.context.cms_db_context).execute(drafts)
-        if result.is_failure():
+        db_pages = result.value() if not result.is_failure() else []
+        db_tuples = {(p['name'], p['language']) for p in db_pages}
+        local_tuples = self.get_local_pages()
+        all_tuples = sorted(db_tuples | local_tuples)
+        
+        if not all_tuples:
             click.echo('There are no pages to list. Create your first one by using the [pages create] command.')
             return
-
-        # TODO: Add repos difference indicators
-
-        for spec in result.value():
-            click.echo(f'{spec["name"]} -> {spec["title"]}')
+            
+        for name, lang in all_tuples:
+            if (name, lang) in db_tuples:
+                # Page exists in DB
+                page = next(p for p in db_pages if p['name'] == name and p['language'] == lang)
+                indicator = '*' if self.has_local_changes(page) else ' '
+                title = page.get('title', '')
+            else:
+                # Page only exists locally
+                indicator = '*'  # Local-only is a difference
+                title = 'Local only'
+            click.echo(f'{indicator} {name} ({lang}) -> {title}')

--- a/elementalcms/management/pagescommands/publish.py
+++ b/elementalcms/management/pagescommands/publish.py
@@ -14,6 +14,9 @@ class Publish:
         self.context: ElementalContext = ctx.obj['elemental_context']
 
     def exec(self, pages) -> [Tuple]:
+
+        root_folder_path = self.context.cms_core_context.PAGES_FOLDER
+        
         if isinstance(pages, str):
             get_all_result = GetAll(self.context.cms_db_context).execute(True)  # Get all drafts
             if get_all_result.is_failure():
@@ -24,7 +27,8 @@ class Publish:
                 click.echo('There are no draft pages to publish.')
                 return []
         else:
-            pages_tuples = pages
+            # Strip PAGES_FOLDER/lang from provided paths if present
+            pages_tuples = [(p[0].replace(f'{root_folder_path}/{p[1]}/', ''), p[1]) for p in pages]
 
         backups_filepaths = []
         for page_tuple in pages_tuples:

--- a/elementalcms/management/pagescommands/pull.py
+++ b/elementalcms/management/pagescommands/pull.py
@@ -16,6 +16,8 @@ class Pull:
 
     def exec(self, pages, drafts: bool) -> [Tuple]:
 
+        root_folder_path = self.context.cms_core_context.PAGES_FOLDER
+
         if isinstance(pages, str):
             get_all_result = GetAll(self.context.cms_db_context).execute(drafts)
             pages_tuples = [] if get_all_result.is_failure() else [(item['name'], item['language'])
@@ -24,10 +26,8 @@ class Pull:
                 click.echo('There are no pages to pull.')
                 return []
         else:
-            pages_tuples = pages
-            # TODO: Support file names with paths
-
-        root_folder_path = self.context.cms_core_context.PAGES_FOLDER
+            # Strip PAGES_FOLDER/lang from provided paths if present
+            pages_tuples = [(p[0].replace(f'{root_folder_path}/{p[1]}/', ''), p[1]) for p in pages]
 
         backups_filepaths = []
         for page_tuple in pages_tuples:

--- a/elementalcms/management/pagescommands/push.py
+++ b/elementalcms/management/pagescommands/push.py
@@ -30,8 +30,8 @@ class Push:
                 click.echo('There are no pages to push.')
                 return
         else:
-            pages_tuples = pages
-            # TODO: Support file names with paths
+            # Strip PAGES_FOLDER/lang from provided paths if present
+            pages_tuples = [(p[0].replace(f'{root_folder_path}/{p[1]}/', ''), p[1]) for p in pages]
 
         backups_filepaths = []
         for page_tuple in pages_tuples:

--- a/elementalcms/management/pagescommands/remove.py
+++ b/elementalcms/management/pagescommands/remove.py
@@ -16,7 +16,10 @@ class Remove:
 
     def exec(self, page_tuple) -> Optional[Tuple]:
 
-        name = page_tuple[0]
+        root_folder_path = self.context.cms_core_context.PAGES_FOLDER
+
+        # Strip PAGES_FOLDER/lang from provided paths if present
+        name = page_tuple[0].replace(f'{root_folder_path}/{page_tuple[1]}/', '')
         lang = page_tuple[1]
 
         get_page_result = GetMeForLanguage(self.context.cms_db_context).execute(name, lang, False, False)

--- a/elementalcms/management/pagescommands/unpublish.py
+++ b/elementalcms/management/pagescommands/unpublish.py
@@ -17,7 +17,10 @@ class Unpublish:
         backups_filepaths = []
         for page_tuple in pages_tuples:
 
-            name = page_tuple[0]
+            root_folder_path = self.context.cms_core_context.PAGES_FOLDER
+
+            # Strip PAGES_FOLDER/lang from provided paths if present
+            name = page_tuple[0].replace(f'{root_folder_path}/{page_tuple[1]}/', '')
             lang = page_tuple[1]
 
             get_page_result = GetMeForLanguage(self.context.cms_db_context).execute(name, lang, False, False)

--- a/elementalcms/management/snippets.py
+++ b/elementalcms/management/snippets.py
@@ -4,7 +4,7 @@ import click
 from cloup import constraint, option, command, pass_context
 from cloup.constraints import RequireExactly
 
-from .snippetscommands import Create, List, Push, Pull, Remove
+from .snippetscommands import Create, List, Push, Pull, Remove, Diff
 
 
 class Snippets(click.Group):
@@ -17,6 +17,7 @@ class Snippets(click.Group):
         self.add_command(self.remove)
         self.add_command(self.push)
         self.add_command(self.pull)
+        self.add_command(self.diff)
 
         # TODO: Add command to find differences between local workspace and CMS database
 
@@ -80,3 +81,13 @@ class Snippets(click.Group):
     @pass_context
     def remove(ctx, snippet) -> Tuple:
         return Remove(ctx).exec(snippet)
+
+    @staticmethod
+    @command(name='diff', help='Compare local and database versions of a snippet.')
+    @option('--snippet',
+            '-s',
+            required=True,
+            help='Name of the snippet to compare. Can include SNIPPETS_FOLDER path (e.g., workspace/snippets/nav-bar).')
+    @pass_context
+    def diff(ctx, snippet) -> Tuple:
+        return Diff(ctx).exec(snippet)

--- a/elementalcms/management/snippetscommands/__init__.py
+++ b/elementalcms/management/snippetscommands/__init__.py
@@ -3,3 +3,4 @@ from .list import List
 from .push import Push
 from .pull import Pull
 from .remove import Remove
+from .diff import Diff

--- a/elementalcms/management/snippetscommands/diff.py
+++ b/elementalcms/management/snippetscommands/diff.py
@@ -1,0 +1,139 @@
+import os
+import json
+from typing import Tuple
+import difflib
+
+import click
+from bson import json_util
+from rich.console import Console
+from rich.text import Text
+from rich.panel import Panel
+
+from elementalcms.core import ElementalContext
+from elementalcms.services.snippets import GetMe
+
+
+class Diff:
+
+    def __init__(self, ctx):
+        self.context: ElementalContext = ctx.obj['elemental_context']
+        self.console = Console()
+
+    def get_local_files(self, name: str) -> Tuple[str, str]:
+        """Get local spec and content files. Returns (spec_json, content_html)"""
+        folder_path = self.context.cms_core_context.SNIPPETS_FOLDER
+        spec_path = f'{folder_path}/{name}.json'
+        content_path = f'{folder_path}/{name}.html'
+
+        spec_json = None
+        content_html = None
+
+        if os.path.exists(spec_path):
+            with open(spec_path, encoding='utf-8') as f:
+                spec_json = f.read()
+
+        if os.path.exists(content_path):
+            with open(content_path, encoding='utf-8') as f:
+                content_html = f.read()
+
+        return spec_json, content_html
+
+    def format_spec(self, spec: dict) -> str:
+        """Format spec for display, removing timestamps and content"""
+        display_spec = spec.copy()
+        display_spec.pop('createdAt', None)
+        display_spec.pop('lastModifiedAt', None)
+        display_spec.pop('content', None)
+        # Convert ObjectId to string format
+        if '_id' in display_spec:
+            display_spec['_id'] = {'$oid': str(display_spec['_id'])}
+        return json.dumps(display_spec, indent=2)
+
+    def show_diff(self, title: str, db_version: str, local_version: str, file_type: str, name: str):
+        """Show unified diff between two versions"""
+        if not db_version and not local_version:
+            return False
+            
+        db_lines = db_version.splitlines(keepends=True) if db_version else []
+        local_lines = local_version.splitlines(keepends=True) if local_version else []
+        
+        diff = list(difflib.unified_diff(
+            db_lines, local_lines,
+            fromfile=f"database/{name}.{file_type}",
+            tofile=f"local/{name}.{file_type}",
+            lineterm=""
+        ))
+        
+        if not diff:
+            return False
+            
+        diff_text = Text()
+        diff_text.append(f"\n{title}:\n", style="bold")
+        
+        header_line = ""
+        for line in diff:
+            if line.startswith('---') or line.startswith('+++') or line.startswith('@@'):
+                header_line += line.rstrip('\n')
+            else:
+                if header_line:
+                    # Split and color each part of the header
+                    parts = header_line.split('@@')
+                    if len(parts) > 1:
+                        file_parts = parts[0].split('+++')
+                        diff_text.append(file_parts[0], style="red")  # --- line
+                        diff_text.append('+++' + file_parts[1], style="green")  # +++ line
+                        diff_text.append('@@' + parts[1] + '@@\n', style="blue")  # @@ line
+                    header_line = ""
+                    diff_text.append('\n')  # Start content on new line
+                
+                # Style and append content lines
+                if line.startswith('+'):
+                    diff_text.append(line, style="green")
+                elif line.startswith('-'):
+                    diff_text.append(line, style="red")
+                else:
+                    diff_text.append(line)
+                    
+        if header_line:  # Handle case where there's only header
+            diff_text.append(header_line + '\n', style="blue")
+        
+        self.console.print(diff_text)
+        return True
+
+    def exec(self, snippet_name: str) -> Tuple:
+        # Handle path if SNIPPETS_FOLDER is provided
+        folder_path = self.context.cms_core_context.SNIPPETS_FOLDER
+        if snippet_name.startswith(folder_path + '/'):
+            snippet_name = snippet_name[len(folder_path) + 1:]
+
+        result = GetMe(self.context.cms_db_context).execute(snippet_name)
+        if result.is_failure():
+            click.echo(f'Snippet {snippet_name} not found in database.')
+            return 1, None
+
+        db_snippet = result.value()
+        db_spec = self.format_spec(db_snippet)
+        db_content = db_snippet.get('content', '')
+
+        local_spec_json, local_content = self.get_local_files(snippet_name)
+        
+        if local_spec_json is None and local_content is None:
+            click.echo(f'No local files found for snippet {snippet_name}.')
+            return 1, None
+
+        local_spec = None
+        if local_spec_json:
+            try:
+                local_spec = self.format_spec(json_util.loads(local_spec_json))
+            except json.JSONDecodeError:
+                local_spec = local_spec_json  # Show raw if invalid JSON
+
+        self.console.print(f"\n[bold]Snippet: {snippet_name}[/bold]")
+
+        has_spec_diff = self.show_diff("Spec Changes", db_spec, local_spec, "json", snippet_name)
+        has_content_diff = self.show_diff("Content Changes", db_content, local_content, "html", snippet_name)
+
+        if not has_spec_diff and not has_content_diff:
+            self.console.print("\n[bold green]No differences found[/bold green]")
+
+        return 0, None

--- a/pypi.md
+++ b/pypi.md
@@ -16,7 +16,7 @@ To install the tool, we can issue the following command:
 pip install elemental-cms
 ```
 
-This will install all the dependencies required for elemental-cms to work. Version 2.0.4 is compatible with:
+This will install all the dependencies required for elemental-cms to work. Version 2.0.5 is compatible with:
 - Flask 2.2.5
 - Werkzeug 2.2.3
 - Flask-Babel 2.0.0

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ It relies on MongoDB to store the metadata, pages' content, snippets' content, d
 
 ## Version Compatibility
 
-Elemental CMS 2.0.4 is compatible with:
+Elemental CMS 2.0.5 is compatible with:
 - Flask 2.2.5
 - Werkzeug 2.2.3
 - Flask-Babel 2.0.0
@@ -23,15 +23,14 @@ For version history and changes, see our [CHANGELOG](CHANGELOG.md).
 - <a href="https://paranoid.software/en/elemental-cms/docs" target="_blank">Official documentation</a> construction
 - Media files management on GCS module test classes
 - Static files management on GCS module test classes
-- Pages management module review and refactor
 - Samples review and update
 
 ## To Do
 
-- Resources names validation
+- Resources names validation for pages (similar to snippets)
 - Configurations schema review
 - Test coverage review
-- Support for detailed comparison between local and remote resources versions
+- Support for pages diff command (similar to snippets)
 - Support for sample settings file generation
 
 ## Configuration Guide
@@ -313,6 +312,9 @@ This will create two files in your SNIPPETS_FOLDER:
 # List all snippets (shows * for snippets that: have local changes, are missing local files, or exist locally but not in the database)
 elemental-cms snippets list
 
+# Compare local and database versions of a snippet
+elemental-cms snippets diff -s nav-bar
+
 # Push a snippet to CMS
 elemental-cms snippets push -s nav-bar
 
@@ -374,10 +376,21 @@ The content file will have the HTML for the page.
 In order to push a page, we must use the "pages push" command:
 
 ```shell
+# List all pages (shows * for pages that: have local changes, are missing local files, or exist locally but not in the database)
+elemental-cms pages list
+
+# Push a page to CMS
 elemental-cms pages push -p home en
 ```
 
-This will save the metadata and content into the database, creating a "draft" version of the page.
+The list command shows an asterisk (*) next to pages that:
+- Have differences between local and database versions
+- Are missing their local files
+- Exist locally but not in the database
+
+This helps you identify which pages need to be pushed or pulled.
+
+When pushing a page, it will save the metadata and content into the database, creating a "draft" version of the page.
 
 ## Publishing a page
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ REQUIREMENTS = [
     'deepdiff>=5.6.0',
     'Flask-Babel==2.0.0',  # Using exact version to ensure compatibility
     'google-cloud-storage>=2.3.0',
-    'MarkupSafe>=2.1.0'
+    'MarkupSafe>=2.1.0',
+    'rich>=13.0.0'  # For pretty terminal output
 ]
 
 

--- a/tests/management/pagescommands/test_listcommandshould.py
+++ b/tests/management/pagescommands/test_listcommandshould.py
@@ -3,6 +3,7 @@ import pytest
 from assertpy import assert_that
 from bson import ObjectId
 from click.testing import CliRunner
+from bson import json_util
 
 from elementalcms.core import MongoDbContext
 from elementalcms.management import cli
@@ -87,3 +88,102 @@ class TestListCommandShould:
                     result = runner.invoke(cli, ['pages',
                                                  'list'])
                     assert_that(all(substring in result.output for substring in ['home', 'privacy-policy']))
+
+    def test_indicate_missing_local_files(self, default_elemental_fixture, default_settings_fixture, pages):
+        with EphemeralMongoContext(MongoDbContext(default_settings_fixture['cmsDbContext']).connection_string,
+                                   initial_state=[
+                                       MongoDbState(db_name='elemental',
+                                                    data=[
+                                                        MongoDbStateData(coll_name='pages',
+                                                                         items=pages)
+                                                    ])
+                                   ]) as (db_name, reader):
+            default_settings_fixture['cmsDbContext']['databaseName'] = db_name
+            runner = CliRunner()
+            with runner.isolated_filesystem():
+                root_folder_path = default_settings_fixture["cmsCoreContext"]["PAGES_FOLDER"]
+                files = [
+                    (f'{root_folder_path}/en/.keep', ''),  # Empty file to ensure folder exists
+                    (f'{root_folder_path}/es/.keep', '')   # Empty file to ensure folder exists
+                ]
+                with EphemeralElementalFileSystem(default_elemental_fixture, default_settings_fixture, files):
+                    # noinspection PyTypeChecker
+                    result = runner.invoke(cli, ['pages', 'list'])
+                    # Should show * for all pages as they don't exist locally
+                    assert_that(result.output).contains('* home (en)')
+                    assert_that(result.output).contains('* home (es)')
+                    assert_that(result.output).contains('* privacy-policy (en)')
+
+    def test_indicate_local_changes(self, default_elemental_fixture, default_settings_fixture, pages):
+        with EphemeralMongoContext(MongoDbContext(default_settings_fixture['cmsDbContext']).connection_string,
+                                   initial_state=[
+                                       MongoDbState(db_name='elemental',
+                                                    data=[
+                                                        MongoDbStateData(coll_name='pages',
+                                                                         items=pages)
+                                                    ])
+                                   ]) as (db_name, reader):
+            default_settings_fixture['cmsDbContext']['databaseName'] = db_name
+            runner = CliRunner()
+            with runner.isolated_filesystem():
+                # Create local files with different content
+                root_folder_path = default_settings_fixture["cmsCoreContext"]["PAGES_FOLDER"]
+                # Create a modified version of home (en)
+                home_en = pages[0].copy()
+                home_en['cssDeps'] = ['style.css']  # Change to trigger difference
+                
+                files = [
+                    # home (en) with changes
+                    (f'{root_folder_path}/en/home.json', json_util.dumps(home_en)),
+                    (f'{root_folder_path}/en/home.html', '<div>Changed</div>'),
+                    # home (es) and privacy-policy exact copy from fixture
+                    (f'{root_folder_path}/es/home.json', json_util.dumps(pages[1])),
+                    (f'{root_folder_path}/es/home.html', pages[1]['content']),
+                    (f'{root_folder_path}/en/privacy-policy.json', json_util.dumps(pages[2])),
+                    (f'{root_folder_path}/en/privacy-policy.html', pages[2]['content'])
+                ]
+                with EphemeralElementalFileSystem(default_elemental_fixture, default_settings_fixture, files):
+                    # noinspection PyTypeChecker
+                    result = runner.invoke(cli, ['pages', 'list'])
+                    # home (en) should show change indicator, others should not
+                    assert_that(result.output).contains('* home (en)')
+                    assert_that(result.output).contains('  home (es)')
+                    assert_that(result.output).contains('  privacy-policy (en)')
+
+    def test_indicate_local_only_pages(self, default_elemental_fixture, default_settings_fixture, pages):
+        with EphemeralMongoContext(MongoDbContext(default_settings_fixture['cmsDbContext']).connection_string,
+                                   initial_state=[
+                                       MongoDbState(db_name='elemental',
+                                                    data=[
+                                                        MongoDbStateData(coll_name='pages',
+                                                                         items=pages)
+                                                    ])
+                                   ]) as (db_name, reader):
+            default_settings_fixture['cmsDbContext']['databaseName'] = db_name
+            runner = CliRunner()
+            with runner.isolated_filesystem():
+                # Create local files including one that's not in the database
+                root_folder_path = default_settings_fixture["cmsCoreContext"]["PAGES_FOLDER"]
+                files = [
+                    # home (es) exact copy from fixture
+                    (f'{root_folder_path}/es/home.json', json_util.dumps(pages[1])),
+                    (f'{root_folder_path}/es/home.html', pages[1]['content']),
+                    # local-only page
+                    (f'{root_folder_path}/en/about.json', json_util.dumps({
+                        '_id': ObjectId(),
+                        'name': 'about',
+                        'language': 'en',
+                        'title': 'About Us',
+                        'description': '',
+                        'isHome': False,
+                        'cssDeps': [],
+                        'jsDeps': []
+                    })),
+                    (f'{root_folder_path}/en/about.html', '<div>About Us</div>')
+                ]
+                with EphemeralElementalFileSystem(default_elemental_fixture, default_settings_fixture, files):
+                    # noinspection PyTypeChecker
+                    result = runner.invoke(cli, ['pages', 'list'])
+                    # home (es) should not show indicator, about (en) should show indicator
+                    assert_that(result.output).contains('  home (es)')
+                    assert_that(result.output).contains('* about (en)')

--- a/tests/management/pagescommands/test_pullcommandshould.py
+++ b/tests/management/pagescommands/test_pullcommandshould.py
@@ -121,5 +121,5 @@ class TestPullCommandShould:
                     # noinspection PyTypeChecker
                     result = runner.invoke(cli, ['pages',
                                                  'pull',
-                                                 '-p', 'home', 'en'])
+                                                 '-p', 'workspace/pages/en/home', 'en'])
                     assert_that(re.findall('pulled successfully', result.output)).is_length(1)

--- a/tests/management/snippetscommands/test_diffcommandshould.py
+++ b/tests/management/snippetscommands/test_diffcommandshould.py
@@ -1,0 +1,113 @@
+import datetime
+import pytest
+from assertpy import assert_that
+from bson import ObjectId
+from click.testing import CliRunner
+from bson import json_util
+
+from elementalcms.core import MongoDbContext
+from elementalcms.management import cli
+from tests import EphemeralMongoContext, EphemeralElementalFileSystem
+from tests.ephemeralmongocontext import MongoDbState, MongoDbStateData
+
+
+class TestDiffCommandShould:
+
+    @pytest.fixture
+    def snippet(self):
+        return {
+            '_id': ObjectId(),
+            'name': 'nav-bar',
+            'content': '<div>Original</div>',
+            'cssDeps': [],
+            'jsDeps': [],
+            'createdAt': datetime.datetime.utcnow(),
+            'lastModifiedAt': datetime.datetime.utcnow()
+        }
+
+    def test_show_error_when_snippet_not_in_db(self, default_elemental_fixture, default_settings_fixture):
+        with EphemeralMongoContext(MongoDbContext(default_settings_fixture['cmsDbContext']).connection_string,
+                                   initial_state=[
+                                       MongoDbState(db_name='elemental',
+                                                    data=[
+                                                        MongoDbStateData(coll_name='snippets',
+                                                                         items=[])
+                                                    ])
+                                   ]) as (db_name, reader):
+            default_settings_fixture['cmsDbContext']['databaseName'] = db_name
+            runner = CliRunner()
+            with runner.isolated_filesystem():
+                with EphemeralElementalFileSystem(default_elemental_fixture, default_settings_fixture):
+                    # noinspection PyTypeChecker
+                    result = runner.invoke(cli, ['snippets', 'diff', '-s', 'nav-bar'])
+                    assert_that(result.output).contains('Snippet nav-bar not found in database.')
+
+    def test_show_error_when_no_local_files(self, default_elemental_fixture, default_settings_fixture, snippet):
+        with EphemeralMongoContext(MongoDbContext(default_settings_fixture['cmsDbContext']).connection_string,
+                                   initial_state=[
+                                       MongoDbState(db_name='elemental',
+                                                    data=[
+                                                        MongoDbStateData(coll_name='snippets',
+                                                                         items=[snippet])
+                                                    ])
+                                   ]) as (db_name, reader):
+            default_settings_fixture['cmsDbContext']['databaseName'] = db_name
+            runner = CliRunner()
+            with runner.isolated_filesystem():
+                with EphemeralElementalFileSystem(default_elemental_fixture, default_settings_fixture):
+                    # noinspection PyTypeChecker
+                    result = runner.invoke(cli, ['snippets', 'diff', '-s', 'nav-bar'])
+                    assert_that(result.output).contains('No local files found for snippet nav-bar.')
+
+    def test_show_no_differences_when_files_match(self, default_elemental_fixture, default_settings_fixture, snippet):
+        with EphemeralMongoContext(MongoDbContext(default_settings_fixture['cmsDbContext']).connection_string,
+                                   initial_state=[
+                                       MongoDbState(db_name='elemental',
+                                                    data=[
+                                                        MongoDbStateData(coll_name='snippets',
+                                                                         items=[snippet])
+                                                    ])
+                                   ]) as (db_name, reader):
+            default_settings_fixture['cmsDbContext']['databaseName'] = db_name
+            runner = CliRunner()
+            with runner.isolated_filesystem():
+                folder_path = default_settings_fixture["cmsCoreContext"]["SNIPPETS_FOLDER"]
+                files = [
+                    (f'{folder_path}/nav-bar.json', json_util.dumps(snippet)),
+                    (f'{folder_path}/nav-bar.html', snippet['content'])
+                ]
+                with EphemeralElementalFileSystem(default_elemental_fixture, default_settings_fixture, files):
+                    # noinspection PyTypeChecker
+                    result = runner.invoke(cli, ['snippets', 'diff', '-s', 'workspace/snippets/nav-bar'])
+                    assert_that(result.output).contains('No differences found')
+
+    def test_show_differences_when_files_differ(self, default_elemental_fixture, default_settings_fixture, snippet):
+        with EphemeralMongoContext(MongoDbContext(default_settings_fixture['cmsDbContext']).connection_string,
+                                   initial_state=[
+                                       MongoDbState(db_name='elemental',
+                                                    data=[
+                                                        MongoDbStateData(coll_name='snippets',
+                                                                         items=[snippet])
+                                                    ])
+                                   ]) as (db_name, reader):
+            default_settings_fixture['cmsDbContext']['databaseName'] = db_name
+            runner = CliRunner()
+            with runner.isolated_filesystem():
+                # Create local files with different content
+                folder_path = default_settings_fixture["cmsCoreContext"]["SNIPPETS_FOLDER"]
+                modified_snippet = snippet.copy()
+                modified_snippet['cssDeps'] = ['style.css']
+                files = [
+                    (f'{folder_path}/nav-bar.json', json_util.dumps(modified_snippet)),
+                    (f'{folder_path}/nav-bar.html', '<div>Changed</div>')
+                ]
+                with EphemeralElementalFileSystem(default_elemental_fixture, default_settings_fixture, files):
+                    # noinspection PyTypeChecker
+                    result = runner.invoke(cli, ['snippets', 'diff', '-s', 'nav-bar'])
+                    # Check for spec changes
+                    assert_that(result.output).contains('-  "cssDeps": []')
+                    assert_that(result.output).contains('+    "style.css"')
+                    # Check for content changes
+                    assert_that(result.output).contains('-<div>Original</div>')
+                    assert_that(result.output).contains('+<div>Changed</div>')
+


### PR DESCRIPTION
- Added `snippets diff` command to compare local and database versions of a snippet, showing differences in both spec and content files in a git-like format
- Added support for using PAGES_FOLDER path in pages push, pull, publish, unpublish and remove commands (e.g., workspace/pages/en/home)
- Added repository difference indicators to `pages list` command: shows `*` for pages that have local changes, are missing local files, or exist locally but not in the database